### PR TITLE
Handle zero-count samples in CPM normalisation

### DIFF
--- a/NN_batch_correct.py
+++ b/NN_batch_correct.py
@@ -29,8 +29,6 @@ from functools import partial
 from pathlib import Path
 from typing import Optional, Tuple
 
-import random
-import os
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
@@ -107,10 +105,23 @@ def configure_torch_backend(disable_tf32: bool = False, enable_cudnn_benchmark: 
 
 
 def library_size_normalize(counts_df: pd.DataFrame, cpm_factor: float = 1e6) -> pd.DataFrame:
-    """Counts (samples x genes) -> CPM -> log1p."""
-    lib_sizes = counts_df.sum(axis=1).replace(0, np.nan)
+    """Counts (samples x genes) -> CPM -> log1p.
+
+    Any samples with zero library size would previously yield NaNs after division;
+    we instead treat those rows as having zero expression across all genes.
+    """
+
+    lib_sizes = counts_df.sum(axis=1)
+    zero_mask = lib_sizes <= 0
+    lib_sizes = lib_sizes.mask(zero_mask, 1.0)
+
     x = counts_df.div(lib_sizes, axis=0) * cpm_factor
     x = np.log1p(x)
+
+    if zero_mask.any():
+        # Zero-count samples should remain zero after log1p(CPM)
+        x.loc[zero_mask] = 0.0
+
     return x
 
 

--- a/NN_batch_correct.py
+++ b/NN_batch_correct.py
@@ -112,7 +112,9 @@ def library_size_normalize(counts_df: pd.DataFrame, cpm_factor: float = 1e6) -> 
     """
 
     lib_sizes = counts_df.sum(axis=1)
-    zero_mask = lib_sizes <= 0
+    if (lib_sizes < 0).any():
+        raise ValueError("Negative library sizes detected. This may indicate data corruption.")
+    zero_mask = lib_sizes == 0
     lib_sizes = lib_sizes.mask(zero_mask, 1.0)
 
     x = counts_df.div(lib_sizes, axis=0) * cpm_factor

--- a/tests/test_preprocessing_utils.py
+++ b/tests/test_preprocessing_utils.py
@@ -31,6 +31,24 @@ def test_library_size_normalize_basic():
     assert np.allclose(out.values, expected.values, rtol=1e-6, atol=1e-6)
 
 
+def test_library_size_normalize_handles_zero_library_rows():
+    df = pd.DataFrame(
+        [[0, 0, 0], [5, 5, 10]],
+        index=["zero", "nonzero"],
+        columns=["g1", "g2", "g3"],
+        dtype=float,
+    )
+
+    out = library_size_normalize(df, cpm_factor=1e6)
+
+    # The zero library row should remain zeros after normalisation and log1p,
+    # while the other row behaves as usual.
+    assert np.allclose(out.loc["zero"].values, 0.0)
+
+    expected_nonzero = np.log1p([1e6 * 5 / 20, 1e6 * 5 / 20, 1e6 * 10 / 20])
+    assert np.allclose(out.loc["nonzero"].values, expected_nonzero)
+
+
 def test_select_hvg_train_only_uses_train_variance():
     # Construct 4 samples (0..3), 4 genes (g0..g3)
     # Make g0 vary only in train, g1 vary only in val, g2 moderate in both, g3 least


### PR DESCRIPTION
## Summary
- avoid NaNs during CPM normalisation by treating zero-library samples as zero-expression rows
- add regression test covering zero-library samples in preprocessing utilities

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4c85a65bc832fb385c21cade89435